### PR TITLE
Added quiz font to furigana (Japanese words)

### DIFF
--- a/templates/Japanese words/template.css
+++ b/templates/Japanese words/template.css
@@ -79,6 +79,9 @@ ul {
 #question {
     font-family: "acgyosyo", "Yu Mincho";
 }
+#question ruby rt {
+    font-family: "acgyosyo", "Yu Mincho";
+}
 .japanese {
     text-align: center;
     font-size: 40px;


### PR DESCRIPTION
As you know, we put furigana on the front to disambiguate readings. They didn't have the quiz font.
Now they should look like this:
![Screenshot_20220108-164521_AnkiDroid](https://user-images.githubusercontent.com/84395172/148657831-c942bc25-904b-4eb7-9d05-6efcc7ea58a0.png)
